### PR TITLE
Fix/area plan

### DIFF
--- a/Runtime/Common/CityObjectUtil.cs
+++ b/Runtime/Common/CityObjectUtil.cs
@@ -2,7 +2,6 @@
 using PLATEAU.CityInfo;
 using System.Linq;
 using UnityEngine;
-using UnityEngine.InputSystem.HID;
 
 namespace Landscape2.Runtime.Common
 {
@@ -35,8 +34,10 @@ namespace Landscape2.Runtime.Common
                 }
             }
 
-            // ToDo TERRAIN_demをどこかに定義したい
-            if (cityObject.name.Contains("TERRAIN_dem"))  //if the ground object is found
+            // ToDo 次の命名規則になることを共通する箇所から取得出来るようにしたい。もしくは他の方法で"TERRAIN_dem"を識別できるようにしたい
+            // ConvertedTerrainData PlaceToSceneRecursive()内でこうなるように名前が付けられる
+            var terrainDemPrefix = "TERRAIN_dem";
+            if (cityObject.name.Contains(terrainDemPrefix))  //if the ground object is found
             {
                 return true;
             }

--- a/Runtime/Common/CityObjectUtil.cs
+++ b/Runtime/Common/CityObjectUtil.cs
@@ -2,6 +2,7 @@
 using PLATEAU.CityInfo;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.InputSystem.HID;
 
 namespace Landscape2.Runtime.Common
 {
@@ -33,6 +34,13 @@ namespace Landscape2.Runtime.Common
                     return true;
                 }
             }
+
+            // ToDo TERRAIN_demをどこかに定義したい
+            if (cityObject.name.Contains("TERRAIN_dem"))  //if the ground object is found
+            {
+                return true;
+            }
+
             return false;
         }
         

--- a/Runtime/LandscapePlanLoader/AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/AreaPlanningEdit.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UIElements;
 using System.Collections.Generic;
 using Landscape2.Runtime.UiCommon;
@@ -257,9 +257,14 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 Debug.LogWarning("Pin is not selected");
                 return;
             }
-            if (vertices.Count < 4)
+
+            // AreaPlanningCollisionHandlerで convexを有効にしているため頂点数が4以上必要
+            // Todo AreaPlannningRegister.csの AddVertexIfClicked()でも同様の条件を扱っている。一か所から数値を参照できるようにするべき
+            const int NumRequiredVertices = 4;
+            bool hasRemovableVertices = vertices.Count < NumRequiredVertices + 1;
+            if (hasRemovableVertices)
             {
-                Debug.LogWarning("The number of vertices is less than 4");
+                Debug.LogWarning("The number of vertices is less than " + (NumRequiredVertices + 1).ToString());
                 return;
             }
 

--- a/Runtime/LandscapePlanLoader/AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/AreaPlanningEdit.cs
@@ -257,10 +257,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 Debug.LogWarning("Pin is not selected");
                 return;
             }
-
-            // AreaPlanningCollisionHandlerで convexを有効にしているため頂点数が4以上必要
-            // Todo AreaPlannningRegister.csの AddVertexIfClicked()でも同様の条件を扱っている。一か所から数値を参照できるようにするべき
-            const int NumRequiredVertices = 4;
+            const int NumRequiredVertices = AreaPlanningModuleRegulation.NumRequiredPins;
             bool hasRemovableVertices = vertices.Count < NumRequiredVertices + 1;
             if (hasRemovableVertices)
             {

--- a/Runtime/LandscapePlanLoader/AreaPlanningModuleRegulation.cs
+++ b/Runtime/LandscapePlanLoader/AreaPlanningModuleRegulation.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Landscape2.Runtime.LandscapePlanLoader
+{
+    /// <summary>
+    /// 景観計画区画の機能に対しての規制をまとめたクラス
+    /// 例えば、景観計画区画に登録時に問題ないかチェックする際のルールは編集結果の反映時にも利用されるはず　
+    /// 　という考えのルールを変数、関数で実装する
+    /// </summary>
+    public static class AreaPlanningModuleRegulation
+    {
+        // 必要なピンの数
+        // AreaPlanningCollisionHandlerで convexを有効にしているため頂点となるピンが4以上必要
+        public const int NumRequiredPins = 4;
+    }
+}

--- a/Runtime/LandscapePlanLoader/AreaPlanningModuleRegulation.cs.meta
+++ b/Runtime/LandscapePlanLoader/AreaPlanningModuleRegulation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4cc22a9db6bf5c41823393a04376bc5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/LandscapePlanLoader/AreaPlanningRegister.cs
+++ b/Runtime/LandscapePlanLoader/AreaPlanningRegister.cs
@@ -1,8 +1,5 @@
-﻿using Landscape2.Runtime.UiCommon;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UIElements;
 
 namespace Landscape2.Runtime.LandscapePlanLoader
 {
@@ -49,10 +46,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 if (hits == null || hits.Length == 0)
                     return;
 
-                // AreaPlanningCollisionHandlerで convexを有効にしているため頂点数が4以上必要
-                // Todo AreaPlanningEdit.csの DeleteVertex()でも同様の条件を扱っている。一か所から数値を参照できるようにするべき
-                const int NumRequiredVertices = 4;
-                if (vertices.Count >= NumRequiredVertices)
+                if (vertices.Count >= AreaPlanningModuleRegulation.NumRequiredPins)
                 {
                     // 最初に生成したPinの場合は区画を閉じる
                     if (displayPinLine.IsClickFirstPin(hits))

--- a/Runtime/LandscapePlanLoader/AreaPlanningRegister.cs
+++ b/Runtime/LandscapePlanLoader/AreaPlanningRegister.cs
@@ -1,4 +1,4 @@
-using Landscape2.Runtime.UiCommon;
+﻿using Landscape2.Runtime.UiCommon;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -49,7 +49,10 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 if (hits == null || hits.Length == 0)
                     return;
 
-                if (vertices.Count > 2)
+                // AreaPlanningCollisionHandlerで convexを有効にしているため頂点数が4以上必要
+                // Todo AreaPlanningEdit.csの DeleteVertex()でも同様の条件を扱っている。一か所から数値を参照できるようにするべき
+                const int NumRequiredVertices = 4;
+                if (vertices.Count >= NumRequiredVertices)
                 {
                     // 最初に生成したPinの場合は区画を閉じる
                     if (displayPinLine.IsClickFirstPin(hits))

--- a/Runtime/LandscapePlanLoader/LandscapePlanMeshModifier.cs
+++ b/Runtime/LandscapePlanLoader/LandscapePlanMeshModifier.cs
@@ -1,4 +1,5 @@
-﻿using PLATEAU.CityGML;
+﻿using Landscape2.Runtime.Common;
+using PLATEAU.CityGML;
 using PLATEAU.CityInfo;
 using UnityEngine;
 
@@ -98,47 +99,15 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         /// <returns>オブジェクトが見つかった場合は対象オブジェクトのRaycastHit、見つからない場合はnull</returns>
         RaycastHit? FindGroundObj(RaycastHit[] hits, bool isIncludeConvertedDemGameObj = true)
         {
-            RaycastHit? res = null;
             foreach (var hit in hits)
             {
                 PLATEAUCityObjectGroup cityObjectData = hit.transform.GetComponent<PLATEAUCityObjectGroup>();
-                if (cityObjectData)
-                    res = FindCOT_TINRelief(hit, cityObjectData);
-                if (res != null) break;  // COT_TINReliefのオブジェクトが見つかった場合はそのオブジェクトを返す
-
-                // 変換されたDemオブジェクトも含める場合
-                // memo Terrainに変換されたDemオブジェクトにはPLATEAUCityObjectGroupがアタッチされていないため回避策として処理を追加　すべての動作に問題ないかは検証が必要
-                if (isIncludeConvertedDemGameObj == true)
-                {
-                    res = FindTerrainDem(hit, hit.transform.gameObject);
-                    if (res != null) break;
-                }
-
-            }
-
-            return res;
-
-            static RaycastHit? FindCOT_TINRelief(RaycastHit hit, PLATEAUCityObjectGroup cityObjectData)
-            {
-                foreach (var rootCityObject in cityObjectData.CityObjects.rootCityObjects)
-                {
-                    if (rootCityObject.CityObjectType == CityObjectType.COT_TINRelief)  //if the ground object is found
-                    {
-                        return hit;
-                    }
-                }
-                return null;
-            }
-
-            static RaycastHit? FindTerrainDem(RaycastHit hit, GameObject cityObject)
-            {
-                // ToDo TERRAIN_demをどこかに定義したい
-                if (cityObject.name.Contains("TERRAIN_dem"))  //if the ground object is found
-                {
+                var isGroud = CityObjectUtil.IsGround(hit.transform.gameObject);
+                if (isGroud)
                     return hit;
-                }
-                return null;
             }
+
+            return null;
         }
     }
 }

--- a/Runtime/LandscapePlanLoader/LandscapePlanMeshModifier.cs
+++ b/Runtime/LandscapePlanLoader/LandscapePlanMeshModifier.cs
@@ -97,13 +97,11 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         /// RaycastHit配列から、cityObjectTypeがCOT_TINReliefのオブジェクトを探索するメソッド
         /// </summary>
         /// <returns>オブジェクトが見つかった場合は対象オブジェクトのRaycastHit、見つからない場合はnull</returns>
-        RaycastHit? FindGroundObj(RaycastHit[] hits, bool isIncludeConvertedDemGameObj = true)
+        RaycastHit? FindGroundObj(RaycastHit[] hits)
         {
             foreach (var hit in hits)
             {
-                PLATEAUCityObjectGroup cityObjectData = hit.transform.GetComponent<PLATEAUCityObjectGroup>();
-                var isGroud = CityObjectUtil.IsGround(hit.transform.gameObject);
-                if (isGroud)
+                if (CityObjectUtil.IsGround(hit.transform.gameObject))
                     return hit;
             }
 

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UIElements;
 using Landscape2.Runtime.UiCommon;
 using static Landscape2.Runtime.LandscapePlanLoader.PlanningUI;
@@ -13,6 +13,8 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         private readonly AreaEditManager areaEditManager;
         private AreaPlanningEdit areaPlanningEdit;
         private Button heightResetButton;
+
+        private PlanningPanelStatus currentStatus = PlanningPanelStatus.Default;
 
         public Panel_AreaPlanningEdit(VisualElement planning, PlanningUI planningUI) : base(planning, planningUI)
         {
@@ -42,6 +44,9 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         /// </summary>
         protected override void OnDisplayPanel(PlanningPanelStatus status)
         {
+            if (currentStatus == status)
+                return; // 既に同じステータスのパネルが表示されている場合は何もしない
+
             if (status == PlanningPanelStatus.EditAreaMain)
             {
                 panel_PointEditor.style.display = DisplayStyle.Flex;
@@ -58,6 +63,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 panel_PointEditor.style.display = DisplayStyle.None;
                 base.HideSnackbar();
             }
+            currentStatus = status;
         }
 
         /// <summary>

--- a/Runtime/LandscapePlanLoader/PlanningUI.cs
+++ b/Runtime/LandscapePlanLoader/PlanningUI.cs
@@ -107,7 +107,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 { uiRoot , DisplayStyle.Flex }
             };
 
-            var isValidStatus = true;
+            var isSkipDisplaySetting = true;
 
             // パネル表示切り替えイベントを発火
             OnChangePlanningPanelDisplay(status);
@@ -139,11 +139,11 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                     break;
 
                 default:
-                    isValidStatus = false;
+                    isSkipDisplaySetting = false;
                     break;
             }
 
-            if (isValidStatus == false)
+            if (isSkipDisplaySetting == false)
             {
                 return;
             }

--- a/Runtime/LandscapePlanLoader/PlanningUI.cs
+++ b/Runtime/LandscapePlanLoader/PlanningUI.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.UIElements;
 using System;
 using System.Collections.Generic;
@@ -92,68 +92,74 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         /// <param name="status"> 表示するパネルステータス </param>
         public void ChangePlanningPanelDisplay(PlanningPanelStatus status)
         {
+            // デフォルトのオプションを設定する関数群
+            var displaySettings = new Dictionary<VisualElement, DisplayStyle>
+            {
+                { title_AreaPlanningInfo, DisplayStyle.Flex},
+                { title_AreaPlanningList , DisplayStyle.Flex},
+                { title_AreaPlanningEditMenu , DisplayStyle.Flex},
+                { panel_AreaPlanningInfo , DisplayStyle.Flex},
+                { panel_AreaPlanningList , DisplayStyle.Flex},
+                { panel_AreaPlanningMenu , DisplayStyle.Flex},
+                { panel_AreaPlanningSubMenu , DisplayStyle.None},
+                { panel_AreaPlanningRegister , DisplayStyle.None},
+                { panel_AreaPlanningEdit , DisplayStyle.None},
+                { uiRoot , DisplayStyle.Flex }
+            };
+
+            var isValidStatus = true;
+
             // パネル表示切り替えイベントを発火
             OnChangePlanningPanelDisplay(status);
+
+            // ステータスに応じて表示設定を変更
             switch (status)
             {
                 // 初期状態
                 case PlanningPanelStatus.Default:
-                    title_AreaPlanningInfo.style.display = DisplayStyle.Flex;
-                    title_AreaPlanningList.style.display = DisplayStyle.Flex;
-                    title_AreaPlanningEditMenu.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningInfo.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningList.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningMenu.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningSubMenu.style.display = DisplayStyle.None;
-                    panel_AreaPlanningRegister.style.display = DisplayStyle.None;
-                    panel_AreaPlanningEdit.style.display = DisplayStyle.None;
-                    uiRoot.style.display = DisplayStyle.Flex;
                     break;
 
                 // リストからエリアが選択された状態
                 case PlanningPanelStatus.ListForcused:
-                    title_AreaPlanningInfo.style.display = DisplayStyle.Flex;
-                    title_AreaPlanningList.style.display = DisplayStyle.Flex;
-                    title_AreaPlanningEditMenu.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningInfo.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningList.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningMenu.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningSubMenu.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningRegister.style.display = DisplayStyle.None;
-                    panel_AreaPlanningEdit.style.display = DisplayStyle.None;
-                    uiRoot.style.display = DisplayStyle.Flex;
+                    displaySettings[panel_AreaPlanningSubMenu] = DisplayStyle.Flex;
                     break;
 
                 // エリア作成時の状態
                 case PlanningPanelStatus.RegisterAreaMain:
-                    title_AreaPlanningInfo.style.display = DisplayStyle.Flex;
-                    title_AreaPlanningList.style.display = DisplayStyle.Flex;
-                    title_AreaPlanningEditMenu.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningInfo.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningList.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningMenu.style.display = DisplayStyle.None;
-                    panel_AreaPlanningSubMenu.style.display = DisplayStyle.None;
-                    panel_AreaPlanningRegister.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningEdit.style.display = DisplayStyle.None;
-                    uiRoot.style.display = DisplayStyle.None;
+                    displaySettings[panel_AreaPlanningMenu] = DisplayStyle.None;
+                    displaySettings[panel_AreaPlanningRegister] = DisplayStyle.Flex;
+                    displaySettings[uiRoot] = DisplayStyle.None;
                     break;
 
                 // エリア編集時の状態
                 case PlanningPanelStatus.EditAreaMain:
-                    title_AreaPlanningInfo.style.display = DisplayStyle.Flex;
-                    title_AreaPlanningList.style.display = DisplayStyle.Flex;
-                    title_AreaPlanningEditMenu.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningInfo.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningList.style.display = DisplayStyle.Flex;
-                    panel_AreaPlanningMenu.style.display = DisplayStyle.None;
-                    panel_AreaPlanningSubMenu.style.display = DisplayStyle.None;
-                    panel_AreaPlanningRegister.style.display = DisplayStyle.None;
-                    panel_AreaPlanningEdit.style.display = DisplayStyle.Flex;
-                    uiRoot.style.display = DisplayStyle.None;
+                    displaySettings[panel_AreaPlanningMenu] = DisplayStyle.None;
+                    displaySettings[panel_AreaPlanningEdit] = DisplayStyle.Flex;
+                    displaySettings[uiRoot] = DisplayStyle.None;
                     break;
 
                 default:
+                    isValidStatus = false;
                     break;
+            }
+
+            if (isValidStatus == false)
+            {
+                return;
+            }
+
+
+            void SetDisplayStyle(VisualElement element, DisplayStyle style)
+            {
+                if (element != null)
+                {
+                    element.style.display = style;
+                }
+            }
+
+            foreach (var kvp in displaySettings)
+            {
+                SetDisplayStyle(kvp.Key, kvp.Value);
             }
         }
 


### PR DESCRIPTION
﻿## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->
・ピンが4つ以上ないと新規登録、変更結果の反映が出来ないように修正
　AreaPlanningCollisionHandlerで convexを有効にしているため頂点数が4以上必要であるため。
・地面判定処理にTERRIAN_dem_が名前に含まれているかを条件に追加
　TERRIAN_dem_には従来、地面判定に必要とされるコンポーネントが付与されていなかったため。
・一部処理が複雑化している部分をリファクタリング

・妥協点
CityObjectUtilのIsGround()内で識別に使用する文字列を直書きしている。
ConvertedTerrainData内でその文字列を作成しているがprivateであるためアクセス出来なかった。

## レビュー依頼前の確認事項
- [ ] ビルドして動作すること
- [x] Devリポジトリのdevelopブランチで動作すること

## マージ時に確認
- [x] （マージボタン押下前）Squash and Mergeが選択されていること
- [ ] （マージ後）リモートの作業ブランチを削除すること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->
[景観計画ツールマニュアル](https://synesthesias.github.io/landscape-design-tool/manual/LandscapePlanningArea.html)に載っている一通り操作。

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
IsGround()の判定でTERRIAN_dem_を条件に加えた影響でPLATEAUCityObjectGroupがアタッチされていないオブジェクトが利用されることがある。
現段階のコードに問題は無かったが新たにコードを追加する時にテライン化した時は動かないといったバグが発生しそう。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 最低ピン数の規則を管理する新しい定数クラスを追加しました。

- **機能改善**
  - 地形オブジェクトの判定方法を強化し、特定の名前パターンを含むオブジェクトも地面として認識するようになりました。
  - 頂点削除やポリゴン閉鎖の条件を定数化し、柔軟に変更できるようになりました。
  - パネル表示処理に重複実行防止のガードを追加し、不要なUI更新を抑制しました。
  - パネル表示切替処理を整理し、UIの表示制御が簡潔になりました。

- **リファクタリング**
  - コード内の重複やハードコーディングを削減し、保守性を向上させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->