### PR TITLE
新規登録後に要素が選択されていない状態で編集開始ボタンを押せてしまう問題の対応。

### DIFF
--- a/Runtime/LandscapePlanLoader/AreaEditManager.cs
+++ b/Runtime/LandscapePlanLoader/AreaEditManager.cs
@@ -1,4 +1,4 @@
-using iShape.Geometry.Polygon;
+﻿using iShape.Geometry.Polygon;
 using UnityEngine;
 using System.Collections.Generic;
 
@@ -57,6 +57,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         public void ChangeHeight(float newHeight)
         {
             if (editingAreaProperty == null) return;
+            if (editingAreaProperty.LimitHeight == newHeight) return;   // 既に同じ高さの場合は何もしない
 
             newHeight = Mathf.Clamp(newHeight, 0, editingAreaProperty.WallMaxHeight);
             editingAreaProperty.LimitHeight = newHeight;

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningRegister.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningRegister.cs
@@ -50,7 +50,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             defaultProperty = new PanelProperty
             {
                 name = areaPlanningName.value,
-                height = float.Parse(areaPlanningHeight.value),
+                height = float.TryParse(areaPlanningHeight.value, out float parsedHeight) ? parsedHeight : limitHeight,
                 color = areaPlanningColor.resolvedStyle.backgroundColor
             };
 

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningRegister.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningRegister.cs
@@ -1,4 +1,4 @@
-using Landscape2.Runtime.UiCommon;
+﻿using Landscape2.Runtime.UiCommon;
 using UnityEngine;
 using UnityEngine.UIElements;
 using static Landscape2.Runtime.LandscapePlanLoader.PlanningUI;
@@ -139,6 +139,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         protected override void OnCancelButtonClicked()
         {
             areaPlanningRegister.ClearVertexEdit();
+            RefreshEditor();
         }
 
         /// <summary>
@@ -162,6 +163,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             areaPlanningRegister.ClearVertexEdit();
             planningUI.InvokeOnChangeConfirmed();
 
+            RefreshEditor();
         }
 
         /// <summary>
@@ -197,6 +199,34 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             {
                 areaPlanningColor.style.backgroundColor = new StyleColor(newColor.Value);
             }
+        }
+
+        /// <summary>
+        /// 編集用UXMLのパラメータ情報を更新
+        /// </summary>
+        /// <param name = "newIndex" > 新規に表示する地区データのリスト番号 </ param >
+        /// <param name="isEditable"></param>
+        void RefreshEditor()
+        {
+            //// 編集中の内容を破棄
+            //areaEditManager.ResetProperty();
+            
+            // 色彩変更画面を閉じる
+            isColorEditing = false;
+            EditColor();
+            //isVertexEditing = false;
+            //// 頂点編集の内容を破棄
+            //areaPlanningEdit.ClearVertexEdit();
+
+            //// 編集対象を更新
+            //areaEditManager.SetEditTarget(newIndex);
+
+            //// 新しい編集対象のデータをUIに反映
+            //string name = areaEditManager.GetAreaName();
+            //float? height = areaEditManager.GetLimitHeight();
+            //areaPlanningName.value = name == null ? "" : name;
+            //areaPlanningHeight.value = height == null ? "" : height.ToString();
+            //areaPlanningColor.style.backgroundColor = areaEditManager.GetColor();
         }
 
     }

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningRegister.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningRegister.cs
@@ -15,6 +15,14 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         private const float wallMaxHeight = 300f;
         private float limitHeight;
 
+        struct PanelProperty
+        {
+            public string name;
+            public float height;
+            public Color color;
+        }
+        private PanelProperty defaultProperty;
+
         public Panel_AreaPlanningRegister(VisualElement planning, PlanningUI planningUI) : base(planning, planningUI)
         {
             areaPlanningRegister = new AreaPlanningRegister(displayPinLine);
@@ -36,6 +44,16 @@ namespace Landscape2.Runtime.LandscapePlanLoader
 
             limitHeight = 15.0f; // 初期値15mで設定
             areaPlanningHeight.value = limitHeight.ToString();
+
+
+            // パネルの初期値を保持
+            defaultProperty = new PanelProperty
+            {
+                name = areaPlanningName.value,
+                height = float.Parse(areaPlanningHeight.value),
+                color = areaPlanningColor.resolvedStyle.backgroundColor
+            };
+
         }
 
         /// <summary>
@@ -214,19 +232,15 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             // 色彩変更画面を閉じる
             isColorEditing = false;
             EditColor();
-            //isVertexEditing = false;
-            //// 頂点編集の内容を破棄
-            //areaPlanningEdit.ClearVertexEdit();
 
-            //// 編集対象を更新
-            //areaEditManager.SetEditTarget(newIndex);
+            // 頂点編集の内容を破棄
+            areaPlanningRegister.ClearVertexEdit();
 
-            //// 新しい編集対象のデータをUIに反映
-            //string name = areaEditManager.GetAreaName();
-            //float? height = areaEditManager.GetLimitHeight();
-            //areaPlanningName.value = name == null ? "" : name;
-            //areaPlanningHeight.value = height == null ? "" : height.ToString();
-            //areaPlanningColor.style.backgroundColor = areaEditManager.GetColor();
+            // 初期値にリセット
+            areaPlanningName.value = defaultProperty.name;
+            areaPlanningHeight.value = defaultProperty.height.ToString();
+            areaPlanningColor.style.backgroundColor = new StyleColor(defaultProperty.color); // StyleColorでないとエラーになるため、StyleColorに変換
+
         }
 
     }

--- a/Runtime/LandscapePlanLoader/PlanningUI.cs
+++ b/Runtime/LandscapePlanLoader/PlanningUI.cs
@@ -79,7 +79,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 }
             };
             // エリア編集が確定されたときに、UIをリスト選択時の画面に戻す
-            OnChangeConfirmed += () => ChangePlanningPanelDisplay(PlanningUI.PlanningPanelStatus.ListForcused);
+            OnChangeConfirmed += () => ChangePlanningPanelDisplay(PlanningUI.PlanningPanelStatus.Default);
 
             InvokeOnFocusedAreaChanged(-1); // エリア未選択の状態でUIを初期化
 


### PR DESCRIPTION
﻿## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->
C30-53
景観計画区域編集完了後にデフォルト画面に戻すようにした。
対応前と後のUIフローの変化。

- 対応前
  - 新規登録、編集後に編集開始ボタンが表示される。
（新規登録時には要素が登録されていないため編集開始ボタンを押すと編集パネルがバグる）
- 対応後
  - 新規登録、編集後には編集開始ボタンが表示されなくなる。
- 共通
  - リストから区域を選択時に編集開始ボタンが表示される。

次の修正内容もこのプルリクに含まれる。
C30-54 [高さ制限された建物を含む区域をリストから選択すると一瞬、建物の大きさ元に戻る現象の修正。](https://github.com/Synesthesias/landscape-design-tool/pull/49/commits/d3354534824e8c20ec65b530ca97c10e4eaf41ec)
C30-64 [完了ボタンを押した時とキャンセルボタンを押した時にカラーパネルを閉じるように修正。](https://github.com/Synesthesias/landscape-design-tool/pull/49/commits/b8e168451717780d7f1972764da3c8d3477d86cf)
C30-62 [再度新規作成パネルを開いた際に初期値にリセットする処理を実装](https://github.com/Synesthesias/landscape-design-tool/pull/49/commits/97d9b8cda940eb2e1aa4199468996e0ac835bb21)
## レビュー依頼前の確認事項
- [x] ビルドして動作すること
- [x] Devリポジトリのdevelopブランチで動作すること

## マージ時に確認
- [ ] （マージボタン押下前）Squash and Mergeが選択されていること
- [ ] （マージ後）リモートの作業ブランチを削除すること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->
- [ ] このプルリクの対応前、対応後の変化に問題ないか？
- [ ] 編集完了後に編集開始ボタンが表示されないようになっていること。
- [ ] 高さ制限された建物が含まれる区域を二つ用意してリストから選択を切り替えても一瞬建物が元のサイズに戻らないこと。
- [ ] 新規作成パネルで登録ボタン、キャンセルボタンを押すとカラーパネルも一緒に閉じること。
- [ ] 一度新規登録した後に再度新規作成パネルを開いても前の情報が残っていないこと。

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
・今回の対応で発生するメリット、デメリット。
- メリット
  - バグらない。編集開始ボタンを含むパネルで画面が占領されない。
- デメリット
  - 新規登録後、編集後に同じ区域に対して編集する時にもう一度、要素を選択する必要がある。
　（間違えて確定押した場合はこういうケース）
　　
・編集開始ボタンのパネルに新規作成や編集ボタンの説明が載っているため、要素を選択するまでその説明が見れないのは不自然かもしれない。
ただ、景観計画区域機能のパネルに切り替えた直後やデータ読み込み直後でも説明が見れないので妥協した。
（説明を別の場所に移す、常時表示してボタンを要素選択時のみボタンを押せるようにするとかはありそう。）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **バグ修正**
  * エリア編集を確定した際、UIパネルの表示がリストフォーカスからデフォルトに戻るようになりました。
  * エリアの高さ変更時、変更がない場合は処理をスキップするようになりました。
* **機能改善**
  * エリアプラン登録パネルの編集画面がキャンセルや確定後に初期状態へリセットされるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->