### PR TITLE
Fix/imporve plan area editing

### DIFF
--- a/Runtime/LandscapePlanLoader/AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/AreaPlanningEdit.cs
@@ -114,9 +114,10 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         }
 
         /// <summary>
-        /// Pinをクリックしたかどうかを判定するメソッド
+        /// シーンビュー上からピンを選択するメソッド
         /// </summary>
-        public bool IsClickPin()
+        /// <returns></returns>
+        public bool SelectPinOnScreen()
         {
             RaycastHit[] hits;
             Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
@@ -137,10 +138,19 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             return false;
         }
 
+
         /// <summary>
-        ///Lineをクリックしたかどうかを判定するメソッド
+        /// Pinをクリックしたかどうかを判定するメソッド
         /// </summary>
-        public bool IsClickLine()
+        public bool IsClickedPin()
+        {
+            return editingPin != null;
+        }
+
+        /// <summary>
+        /// シーンビュー上からラインを選択するメソッド
+        /// </summary>
+        public bool SelectLineOnScreen()
         {
             RaycastHit[] hits;
             Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
@@ -161,6 +171,14 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         }
 
         /// <summary>
+        ///Lineをクリックしたかどうかを判定するメソッド
+        /// </summary>
+        public bool IsClickedLine()
+        {
+            return editingLine != null;
+        }
+
+        /// <summary>
         ///Lineの中点に新しく頂点を追加するメソッド
         /// </summary>
         public void AddVertexToLine()
@@ -174,6 +192,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
 
             //// y座標は前後の頂点の中点の座標にする           
             Vector3 previousVec = vertices[lineIndex];
+        
             Vector3 nextVec;
             if (lineIndex == vertices.Count - 1)
             {

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
@@ -16,9 +16,10 @@ namespace Landscape2.Runtime.LandscapePlanLoader
 
         private PlanningPanelStatus currentStatus = PlanningPanelStatus.Default;
 
-        // ビューポート内で既に消費されているクリックかどうか。消費されている場合はダブルクリック以降の処理は行わない。
-        // 例えば一回目のクリックでピンを追加、ピンの移動を開始、ピンの移動を終了している場合は消費されたとする。
-        // ただし、カメラ移動のマウスドラッグの起点では消費はしない。別のクラスで処理されているため。
+        // ビューポート内で既に消費されているクリックかどうか。消費されている場合はダブルクリック以降の処理は行わない。マウスドラッグの操作は許可する。
+        // 例えば一回目のクリックでピンを追加やピンの移動を開始している場合は消費されたとして2回目のクリックでピンを削除することは出来ない。
+        // 例外として
+        // カメラ移動のマウスドラッグの起点では消費はしない。別のクラスで処理されているため。
         // UIToolkit類のボタンのクリックは考慮していない。
         private bool isClickConsumedOnViewport = false;
 
@@ -200,13 +201,13 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 isClickConsumedOnViewport = false;
             }
 
-            // 消費済みの場合はビューポート上の操作を行わない。
+            // クリック消費済みの場合はシーンビュー上のクリック操作を行わない。
             if (isClickConsumedOnViewport)
                 return;
 
             if (areaPlanningEdit.SelectPinOnScreen()) // ピンをクリック 
             {
-                if (e.clickCount == 2) // ダブルクリックした場合は頂点を削除
+                if (e.clickCount % 2 == 0) // ダブルクリックした場合は頂点を削除
                 {
                     isClickConsumedOnViewport = true;
                     areaPlanningEdit.DeleteVertex();
@@ -243,8 +244,6 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         /// </summary>
         private void OnReleasePanel()
         {
-            isClickConsumedOnViewport = true; // クリック消費状態にする Release直後にピン類を操作するとダブルクリックになるため。
-
             if (areaPlanningEdit.IsIntersected())
             {
                 base.DisplaySnackbar("頂点が交差したエリアは作成できません");

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
@@ -191,7 +191,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         }
 
         /// <summary>
-        /// 頂点編集パネルをクリックしたときの処理
+        /// 頂点編集パネルが開いている時にマウスクリックしたときの処理
         /// </summary>
         private void OnClickPanel(MouseDownEvent e)
         {
@@ -230,7 +230,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         }
 
         /// <summary>
-        /// 頂点編集パネルをドラッグしたときの処理
+        /// 頂点編集パネルが開いている時にマウス移動したときの処理
         /// </summary>
         private void OnDragPanel()
         {
@@ -242,7 +242,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         }
 
         /// <summary>
-        /// 頂点編集パネルのクリックを解除したときの処理
+        /// 頂点編集パネルが開いている時にクリックを解除したときの処理
         /// </summary>
         private void OnReleasePanel()
         {

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
@@ -195,41 +195,36 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         /// </summary>
         private void OnClickPanel(MouseDownEvent e)
         {
-            // 初回クリック時にクリック消費状態をリセット
-            if (e.clickCount == 1)
+            // 初回クリック時やフラグ有効時にクリック消費状態をリセット
+            if (e.clickCount == 1 || isNeedReoffsetClickCount)
             {
-                clickCountOffset = 0;
+                clickCountOffset = e.clickCount - 1; // e.clickCount == 1 : 0, isNeedReoffsetClickCount : どこかでフラグが有効化された際のクリック数
                 isNeedReoffsetClickCount = false;
             }
-            else if (isNeedReoffsetClickCount) // 頂点の移動や削除を行った場合はクリック数のオフセットをリセットする
-            {
-                clickCountOffset = e.clickCount - 1;    // どこかでフラグが有効になり次のクリックでリセットされるため、1を引く。
-                isNeedReoffsetClickCount = false;
-            }
+
+            // これ以降の処理ではクリック消費の対象となる操作が行われるとする。例外があれば そこでfalseを設定する。
+            isNeedReoffsetClickCount = true;
 
             if (areaPlanningEdit.SelectPinOnScreen()) // ピンをクリック 
             {
                 if (e.clickCount == clickCountOffset + 2) // ダブルクリックした場合は頂点を削除
                 {
-                    isNeedReoffsetClickCount = true;
                     areaPlanningEdit.DeleteVertex();
                 }
                 else // 通常クリックの場合は頂点を移動
                 {
-                    // // isNeedReoffsetClickCount = true; // ここでフラグを有効化するとダブルクリックの前にリセットされる。
+                    isNeedReoffsetClickCount = false; // ここでフラグを有効化するとダブルクリックの前にリセットされる。 代わりにドラッグが行われた際にフラグを有効化している。
                     CameraMoveByUserInput.IsCameraMoveActive = false;
                 }
             }
             else if (areaPlanningEdit.SelectLineOnScreen()) // ラインをクリック
             {
-                isNeedReoffsetClickCount = true;
                 CameraMoveByUserInput.IsCameraMoveActive = false;
                 // 中点に頂点を追加
                 areaPlanningEdit.AddVertexToLine();
             }
             else
             {
-                isNeedReoffsetClickCount = true;
                 CameraMoveByUserInput.IsCameraMoveActive = true;    // 消しても景観計画区域の編集時には動作したが別の機能でのフラグの扱いや機能増築時を考慮した設計に必要かもかもしれないので残しておく。
             }
         }

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
@@ -204,7 +204,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             if (isClickConsumedOnViewport)
                 return;
 
-            if (areaPlanningEdit.IsClickPin()) // ピンをクリック 
+            if (areaPlanningEdit.SelectPinOnScreen()) // ピンをクリック 
             {
                 if (e.clickCount == 2) // ダブルクリックした場合は頂点を削除
                 {
@@ -216,7 +216,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                     CameraMoveByUserInput.IsCameraMoveActive = false;
                 }
             }
-            else if (areaPlanningEdit.IsClickLine()) // ラインをクリック
+            else if (areaPlanningEdit.SelectLineOnScreen()) // ラインをクリック
             {
                 isClickConsumedOnViewport = true;
                 CameraMoveByUserInput.IsCameraMoveActive = false;

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
@@ -199,6 +199,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             if (e.clickCount == 1)
             {
                 clickCountOffset = 0;
+                isNeedReoffsetClickCount = false;
             }
             else if (isNeedReoffsetClickCount) // 頂点の移動や削除を行った場合はクリック数のオフセットをリセットする
             {
@@ -227,8 +228,8 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             }
             else
             {
+                isNeedReoffsetClickCount = true;
                 CameraMoveByUserInput.IsCameraMoveActive = true;    // 消しても景観計画区域の編集時には動作したが特定の条件でこの処理が必要になるかもしれないので残しておく。
-                //clickCountOffset = e.clickCount;    // 何も無いところをクリックしたためリセット
             }
         }
 
@@ -237,7 +238,10 @@ namespace Landscape2.Runtime.LandscapePlanLoader
         /// </summary>
         private void OnDragPanel()
         {
-            isNeedReoffsetClickCount = true; // 頂点の移動や削除を行った場合はクリック数のオフセットをリセットする必要がある。
+            if (areaPlanningEdit.IsClickedPin())
+            {
+                isNeedReoffsetClickCount = true; // 頂点の移動や削除を行った場合はクリック数のオフセットをリセットする必要がある。
+            }
             areaPlanningEdit.OnDragPin();
         }
 

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
@@ -230,7 +230,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
             else
             {
                 isNeedReoffsetClickCount = true;
-                CameraMoveByUserInput.IsCameraMoveActive = true;    // 消しても景観計画区域の編集時には動作したが特定の条件でこの処理が必要になるかもしれないので残しておく。
+                CameraMoveByUserInput.IsCameraMoveActive = true;    // 消しても景観計画区域の編集時には動作したが別の機能でのフラグの扱いや機能増築時を考慮した設計に必要かもかもしれないので残しておく。
             }
         }
 

--- a/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
+++ b/Runtime/LandscapePlanLoader/Panel_AreaPlanningEdit.cs
@@ -216,6 +216,7 @@ namespace Landscape2.Runtime.LandscapePlanLoader
                 }
                 else // 通常クリックの場合は頂点を移動
                 {
+                    // // isNeedReoffsetClickCount = true; // ここでフラグを有効化するとダブルクリックの前にリセットされる。
                     CameraMoveByUserInput.IsCameraMoveActive = false;
                 }
             }


### PR DESCRIPTION
﻿## 実装内容
<!-- 実装した内容、背景について書く。妥協点があれば書いておく。 -->
元のタスク
・区域の形状を編集する際にピンを追加してそのピンを動かそうとするとダブルクリックの判定を適切な時間にする？
C30-55


クリック消費の概念を追加。
修正前は1回目のクリックで頂点を追加直後に2回目のクリックがダブルクリック判定になり頂点を削除してしまう状況だった。
修正後はクリックで何か処理をした場合にまた1からクリック数をカウントするようになっている。

頂点追加→移動といった流れがスムーズに行えるはず。

## レビュー依頼前の確認事項
- [ ] ビルドして動作すること
- [x] Devリポジトリのdevelopブランチで動作すること

## マージ時に確認
- [ ] （マージボタン押下前）Squash and Mergeが選択されていること
- [ ] （マージ後）リモートの作業ブランチを削除すること

## 動作確認
<!-- レビュアーが動作確認するのに必要な手順と結果を書く。 -->
テスト方法（準備を除いて連続でクリックしたと検出される範囲で素早く操作が必要。数値はクリック数。）
適当に区域を作成
- [ ] 1.ピンを追加後、1.頂点の移動が出来る。
- [ ] 1.頂点の移動後、2.そのピンを削除できる。
- [ ] 2.ピンを削除後、1.ピンを追加出来る。
- [ ] その他、自由に操作して違和感を感じないか。

## その他
<!-- 気になる点、特にレビューしてほしい点等があれば書く。 -->
元のタスクから今回の対応にした理由。
ダブルクリック判定の時間はOSの設定されている値を利用しているらしくUnityのAPIからはアクセス出来ないらしい。
また、頂点追加後にそのまま移動が出来るようにしたかったため今回のクリック消費の概念を追加した。
本当は頂点追加でクリックしたまま移動出来るようにしたかったが関係する関数を呼ぶだけでは出来なかったため妥協した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ピンやラインの選択状態を判定する機能を追加しました。
  * 頂点の追加・移動・削除時のクリック回数管理がより正確になりました。

* **リファクタリング**
  * ピンやラインの選択・クリック検出処理のメソッド名と役割を整理しました。
  * クリック回数のオフセット管理ロジックを改善し、複雑な操作時の挙動を最適化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->